### PR TITLE
docs: update readme and makefile with default port mappings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,4 +2,4 @@ build-docker:
 	docker build -t ci-dashboard:latest .
 
 serve: build-docker
-	docker run --rm -it -p 9999:9999 -v "$$PWD"/cache:/src/cache -e CIRCLECI_TOKEN="${CIRCLECI_TOKEN}" ci-dashboard:latest -b 0.0.0.0
+	docker run --rm -it -p 8080:8080 -v "$$PWD"/allowed_slugs.json:/src/allowed_slugs.json -v "$$PWD"/cache:/src/cache -e CIRCLECI_TOKEN="${CIRCLECI_TOKEN}" ci-dashboard:latest -b 0.0.0.0

--- a/README.rst
+++ b/README.rst
@@ -15,11 +15,11 @@ of repositories that may be accessed, e.g.,
 
 -  Run ``pip install -r requirements.txt`` to install dependencies.
 -  Run ``python serv.py``.
--  Access the server at ``http://localhost:9999``.
+-  Access the server at ``http://localhost:8080``.
 
 ********
  Docker
 ********
 
 -  Run ``make serve``.
--  Access the server at ``http://localhost:9999``.
+-  Access the server at ``http://localhost:8080``.

--- a/circleci.py
+++ b/circleci.py
@@ -2,7 +2,6 @@
 
 import json
 import os
-import sys
 import time
 
 import requests

--- a/cisummary.py
+++ b/cisummary.py
@@ -1,7 +1,6 @@
 # coding: pyxl
 
 import argparse
-import enum
 import json
 import os
 import queue

--- a/timeline.py
+++ b/timeline.py
@@ -1,15 +1,12 @@
 #!/usr/bin/env python3
 
 from typing import List, NamedTuple
-import json
-import math
 import os
 import sys
 import time
 
 from matplotlib import pyplot as plt, ticker
 import matplotlib
-import requests
 
 import circleci
 


### PR DESCRIPTION
Looks like the default port mappings changed somewhat recently; however the readme, makefile, and our confluence articles all say to use port 9999.

This wasn't hard to figure out and fix, but it'll be even easier for the next user(s) if they don't have to do this and can have it "just work" when they follow the readme instructions.